### PR TITLE
Locked tokens fix

### DIFF
--- a/contracts/bondingcurve/CommonsToken.sol
+++ b/contracts/bondingcurve/CommonsToken.sol
@@ -203,7 +203,7 @@ contract CommonsToken is BondingCurveToken, Pausable {
     // We should only update the total unlocked when it is less than 100%.
 
     // TODO: add vesting period ended flag and optimise check.
-    unlockedInternal += _externalAllocated / p0;
+    unlockedInternal += _externalAllocated * p0;
     if (unlockedInternal >= initialRaise * p0) {
       unlockedInternal = initialRaise * p0;
     }
@@ -222,9 +222,9 @@ contract CommonsToken is BondingCurveToken, Pausable {
     uint256 lockedInternal = initialContributions[msg.sender].lockedInternal;
 
     // The total amount of INTERNAL tokens that should have been unlocked.
-    uint256 shouldHaveUnlockedInternal = (paidExternal * unlockedInternal) / initialRaise;
+    uint256 shouldHaveUnlockedInternal = (paidExternal * p0 * unlockedInternal) / (initialRaise * p0);
     // The amount of INTERNAL tokens that was already unlocked.
-    uint256 previouslyUnlockedInternal = (paidExternal / p0) - lockedInternal;
+    uint256 previouslyUnlockedInternal = (paidExternal * p0) - lockedInternal;
     // The amount that can be unlocked.
     uint256 toUnlock = shouldHaveUnlockedInternal - previouslyUnlockedInternal;
 
@@ -324,7 +324,7 @@ contract CommonsToken is BondingCurveToken, Pausable {
     externalToken.transfer(feeRecipient, frictionCost);
 
     if (feeRecipient != fundingPool) {
-      unlockedInternal += frictionCost / p0;
+      unlockedInternal += frictionCost * p0;
     }
 
     uint256 lockedInternalMax = initialRaise * p0;

--- a/contracts/bondingcurve/CommonsToken.sol
+++ b/contracts/bondingcurve/CommonsToken.sol
@@ -14,7 +14,7 @@ contract CommonsToken is BondingCurveToken, Pausable {
   /**
     PreHatchContribution keeps track of the contribution of a hatcher during the hatchin phase:
       - paidExternal: the amount contributed during the hatching phase, denominated in external currency
-      - lockedInternal: paidExternal / p0 = the amount of internal tokens represented by paidExternal
+      - lockedInternal: paidExternal * p0 = the amount of internal tokens represented by paidExternal
 
     These tokens are unlocked post-hatch according to a vesting policy. Post hatch, we decrease lockedInternal to 0
   */
@@ -328,7 +328,7 @@ contract CommonsToken is BondingCurveToken, Pausable {
     }
 
     uint256 lockedInternalMax = initialRaise * p0;
-    
+
     if (unlockedInternal > initialRaise * p0) {
       unlockedInternal = lockedInternalMax;
     }

--- a/contracts/bondingcurve/CommonsToken.sol
+++ b/contracts/bondingcurve/CommonsToken.sol
@@ -228,6 +228,11 @@ contract CommonsToken is BondingCurveToken, Pausable {
     // The amount that can be unlocked.
     uint256 toUnlock = shouldHaveUnlockedInternal - previouslyUnlockedInternal;
 
+    // Safety check in case the calculation shouldHaveUnlockedInternal causes an overflow.
+    if (toUnlock >= lockedInternal) {
+      toUnlock = lockedInternal;
+    }
+
     initialContributions[msg.sender].lockedInternal -= toUnlock;
     _transfer(address(this), msg.sender, toUnlock);
   }
@@ -320,6 +325,12 @@ contract CommonsToken is BondingCurveToken, Pausable {
 
     if (feeRecipient != fundingPool) {
       unlockedInternal += frictionCost / p0;
+    }
+
+    uint256 lockedInternalMax = initialRaise * p0;
+    
+    if (unlockedInternal > initialRaise * p0) {
+      unlockedInternal = lockedInternalMax;
     }
 
     return reimbursement;

--- a/test/01_artist_token.js
+++ b/test/01_artist_token.js
@@ -61,7 +61,7 @@ contract("ArtistToken", ([lightstreams, hatcher1, hatcher2, lateInvestor]) => {
   });
 
   describe('Initial State', () => {
-    describe('When new ArtistToken is jut deployed', () => {
+    describe('When new ArtistToken is just deployed', () => {
       it("Should have no tokens created", async () => {
         let raisedExternal = await artistToken.raisedExternal();
 

--- a/test/01_artist_token.js
+++ b/test/01_artist_token.js
@@ -30,7 +30,7 @@ contract("ArtistToken", ([lightstreams, hatcher1, hatcher2, lateInvestor]) => {
 
   const RESERVE_RATIO = 142857; // kappa ~ 6
   const THETA = 350000; // 35% in ppm
-  const P0 =  1;
+  const P0 =  2;
   const FRICTION = 20000; // 2% in ppm
   const GAS_PRICE_WEI = 15000000000; // 15 gwei
   const HATCH_DURATION_SECONDS = 3024000; // 5 weeks
@@ -160,7 +160,7 @@ contract("ArtistToken", ([lightstreams, hatcher1, hatcher2, lateInvestor]) => {
 
           it("Should have minted the correct amount to the bonding curve contract", async function() {
             let internalTokensInBondingCurve = await artistToken.balanceOf(artistToken.address);
-            assert.equal(internalTokensInBondingCurve.toString(), pht2wei((AMOUNT_TO_RAISE_PHT / P0 ) * (1 - (THETA  / DENOMINATOR_PPM))).toString());
+            assert.equal(internalTokensInBondingCurve.toString(), pht2wei((AMOUNT_TO_RAISE_PHT * P0 )).toString());
           })
 
           it("Should have ended the hatching phase", async function() {

--- a/test/02_artist_token_flow.js
+++ b/test/02_artist_token_flow.js
@@ -31,7 +31,7 @@ contract("ArtistTokenFlow", ([artist, hatcher1, hatcher2, buyer1, buyer2, fundin
 
   const RESERVE_RATIO = 142857; // kappa ~ 6
   const THETA = 350000; // 35% in ppm
-  const P0 =  1; // price to purchase during hatching
+  const P0 =  2; // price to purchase during hatching
   const FRICTION = 20000; // 2% in ppm
   const GAS_PRICE_WEI = 15000000000; // 15 gwei
   const HATCH_DURATION_SECONDS = 3024000; // 5 weeks
@@ -151,7 +151,7 @@ contract("ArtistTokenFlow", ([artist, hatcher1, hatcher2, buyer1, buyer2, fundin
 
   it('should create a reserve of Artist tokens', async () => {
     const tokensAmount = await artistToken.balanceOf(artistToken.address);
-    const tokensAmountExpected = pht2wei((AMOUNT_TO_RAISE_PHT / P0 ));
+    const tokensAmountExpected = pht2wei((AMOUNT_TO_RAISE_PHT * P0 ));
 
     console.log(`Artist tokens in reserve: ${wei2pht(tokensAmount)} ${artistTokenSymbol}`);
 

--- a/test/04_claim_tokens_overflow.js
+++ b/test/04_claim_tokens_overflow.js
@@ -4,7 +4,8 @@
  * Copyright 2019 (c) Lightstreams, Granada
  */
 
-const { BN } = require('openzeppelin-test-helpers');
+const { BN, ether } = require('openzeppelin-test-helpers');
+
 const { pht2wei, wei2pht } = require('./utils');
 
 const FundingPool = artifacts.require("FundingPool.sol");
@@ -23,7 +24,7 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer, feeRecipient]) => {
 
   const RESERVE_RATIO = 142857; // kappa ~ 6
   const THETA = 350000; // 35% in ppm
-  const P0 =  1; // price to purchase during hatching
+  const P0 =  2; // price to purchase during hatching
   const FRICTION = 20000; // 2% in ppm
   const GAS_PRICE_WEI = 15000000000; // 15 gwei
   const HATCH_DURATION_SECONDS = 3024000; // 5 weeks
@@ -67,6 +68,17 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer, feeRecipient]) => {
     await fundingPool.allocateFunds(artistToken.address, artist, balance, {from: artist });
   });
 
+  it("should allow hatcher to claim a proportion of tokens", async () => {
+    const artistBalance = await wPHT.balanceOf(artist);
+    const expectedHatcherBalance = artistBalance.mul(new BN(P0));
+
+    await artistToken.claimTokens({from: hatcher});
+
+    const balance = await artistToken.balanceOf(hatcher);
+
+    assert.equal(web3.utils.fromWei(balance), web3.utils.fromWei(expectedHatcherBalance));
+  });
+
   // Should increase overall economy (paidExternal * unlockedInternal) / initialRaise
   it("should generate income for feeReipient and unlock hatcher funds", async () => {
     const buyerWei = pht2wei(AMOUNT_TO_RAISE_PHT * 100);
@@ -83,13 +95,13 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer, feeRecipient]) => {
   it("should allow hatcher to claimed tokens", async () => {
     const contribution = await artistToken.initialContributions(hatcher);
     const lockedInternal = contribution.lockedInternal;
+    const preBalance = await artistToken.balanceOf(hatcher);
+    const expectedBalance = preBalance.add(lockedInternal);
 
-    // FAILS - This function calculates that the hatcher to claim more tokens that they have been allocated.
-    // This is because during CommonsToken.burn() the variable CommonsToken.unlockedInternal has increased to greater than CommonsToken.initialRaise()
     await artistToken.claimTokens({from: hatcher});
 
-    const balance = await artistToken.balanceOf(hatcher);
+    const postBalance = await artistToken.balanceOf(hatcher);
 
-    assert.equal(lockedInternal.toString(), balance.toString());
+    assert.equal(expectedBalance.toString(), postBalance.toString());
   });
 });

--- a/test/04_claim_tokens_overflow.js
+++ b/test/04_claim_tokens_overflow.js
@@ -11,7 +11,7 @@ const FundingPool = artifacts.require("FundingPool.sol");
 const WPHT = artifacts.require("WPHT.sol");
 const ArtistToken = artifacts.require("ArtistToken.sol");
 
-contract("ClaimTokensOverflow", ([artist, hatcher, buyer]) => {
+contract("ClaimTokensOverflow", ([artist, hatcher, buyer, feeRecipient]) => {
   let fundingPool;
   let wPHT;
   let artistToken;
@@ -39,7 +39,7 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer]) => {
     artistToken = await ArtistToken.new(
       ARTIST_NAME,
       ARTIST_SYMBOL,
-      [wPHT.address, fundingPool.address, fundingPool.address, artist],
+      [wPHT.address, fundingPool.address, feeRecipient, artist],
       [GAS_PRICE_WEI, THETA, P0, AMOUNT_TO_RAISE_WEI, FRICTION, HATCH_DURATION_SECONDS, HATCH_VESTING_DURATION_SECONDS, AMOUNT_TO_RAISE_WEI],
       RESERVE_RATIO,
       { from: artist, gas: 10000000 }
@@ -62,8 +62,13 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer]) => {
     assert.isTrue(isHatched);
   });
 
+  it("should let artist to withdraw funds", async () => {
+    const balance = await wPHT.balanceOf(fundingPool.address);
+    await fundingPool.allocateFunds(artistToken.address, artist, balance, {from: artist });
+  });
+
   // Should increase overall economy (paidExternal * unlockedInternal) / initialRaise
-  it("should let attacker to make fundingpool rich", async () => {
+  it("should generate income for feeReipient and unlock hatcher funds", async () => {
     const buyerWei = pht2wei(AMOUNT_TO_RAISE_PHT * 100);
 
     await wPHT.deposit({ from: buyer, value: buyerWei});
@@ -75,15 +80,12 @@ contract("ClaimTokensOverflow", ([artist, hatcher, buyer]) => {
     await artistToken.burn(balance, {from: buyer, gasPrice: GAS_PRICE_WEI});
   });
 
-  it("should let artist to withdraw the hatching + burning fee funds", async () => {
-    const balance = await wPHT.balanceOf(fundingPool.address);
-    await fundingPool.allocateFunds(artistToken.address, artist, balance, {from: artist });
-  });
-
-  it("a hatcher claimed tokens do not overflow after ReservePool fix", async () => {
+  it("should allow hatcher to claimed tokens", async () => {
     const contribution = await artistToken.initialContributions(hatcher);
     const lockedInternal = contribution.lockedInternal;
 
+    // FAILS - This function calculates that the hatcher to claim more tokens that they have been allocated.
+    // This is because during CommonsToken.burn() the variable CommonsToken.unlockedInternal has increased to greater than CommonsToken.initialRaise()
     await artistToken.claimTokens({from: hatcher});
 
     const balance = await artistToken.balanceOf(hatcher);


### PR DESCRIPTION
This PR fixes the following two bugs.

BUG 1: Running test 04_claim_tokens_overflow.js shows that a hatcher is unable to claim their tokens.

The function CommonsToken.claimTokens() calculates that the hatcher can claim more tokens that they have been allocated. This is because during CommonsToken.burn() the variable CommonsToken.unlockedInternal has increased to greater than CommonsToken.initialRaise().

BUG 2: Running test 04_claim_tokens_overflow.js shows that the incorrect amount of tokens are unlocked.

This is because the calculation for unlocking tokens using p0 is incorrect.